### PR TITLE
Fix Import of scikit-learn `parse_version`

### DIFF
--- a/quantile_forest/_quantile_forest.py
+++ b/quantile_forest/_quantile_forest.py
@@ -38,6 +38,7 @@ from sklearn.ensemble._forest import (
 )
 from sklearn.tree import DecisionTreeRegressor, ExtraTreeRegressor
 from sklearn.tree._tree import DTYPE
+
 try:
     from sklearn.utils.fixes import parse_version
 except ImportError:

--- a/quantile_forest/_quantile_forest.py
+++ b/quantile_forest/_quantile_forest.py
@@ -38,7 +38,10 @@ from sklearn.ensemble._forest import (
 )
 from sklearn.tree import DecisionTreeRegressor, ExtraTreeRegressor
 from sklearn.tree._tree import DTYPE
-from sklearn.utils import parse_version
+try:
+    from sklearn.utils.fixes import parse_version
+except ImportError:
+    from sklearn.utils import parse_version
 
 param_validation = True
 try:


### PR DESCRIPTION
Fixes import of scikit-learn `parse_version` for scikit-learn 1.5.