### PR TITLE
Support scikit-learn 1.9 (DTYPE removed from sklearn.tree._tree)

### DIFF
--- a/quantile_forest/_quantile_forest.py
+++ b/quantile_forest/_quantile_forest.py
@@ -37,7 +37,11 @@ from sklearn.ensemble._forest import (
     _get_n_samples_bootstrap,
 )
 from sklearn.tree import DecisionTreeRegressor, ExtraTreeRegressor
-from sklearn.tree._tree import DTYPE
+
+try:
+    from sklearn.tree._tree import DTYPE
+except ImportError:  # scikit-learn >= 1.9 no longer re-exports DTYPE here
+    DTYPE = np.float32  # the value DTYPE has always held
 from sklearn.utils._param_validation import Interval, RealNotInt
 from sklearn.utils.fixes import parse_version
 from sklearn.utils.validation import check_is_fitted


### PR DESCRIPTION
## Problem

`import quantile_forest` raises `ImportError` on scikit-learn 1.9:

```
ImportError: cannot import name 'DTYPE' from 'sklearn.tree._tree'
```

scikit-learn 1.9 no longer re-exports `DTYPE` from `sklearn.tree._tree`. `quantile_forest/_quantile_forest.py` imports it at module load, so the whole package fails to import under scikit-learn ≥ 1.9.

## Fix

`DTYPE` has always been `np.float32`, and it is used here only as the coercion dtype passed to `validate_data`/`check_X_y` (the two `"dtype": DTYPE` call sites). So guard the import with a fallback to `np.float32`:

```python
try:
    from sklearn.tree._tree import DTYPE
except ImportError:  # scikit-learn >= 1.9 no longer re-exports DTYPE here
    DTYPE = np.float32  # the value DTYPE has always held
```

- **Identical value** — no behavior change on any scikit-learn version.
- **Backward compatible** — older scikit-learn still imports the real symbol.
- **Forward compatible** — verified `import quantile_forest`-equivalent against scikit-learn 1.9.0: the old import raises, the fallback yields `np.float32`.
- Pure-Python, single line region; `numpy as np` is already imported in this module.

## Verification

```
$ python -c "import sklearn; print(sklearn.__version__)"
1.9.0
$ python -c "from sklearn.tree._tree import DTYPE"
ImportError: cannot import name 'DTYPE' from 'sklearn.tree._tree'   # before
# after this change: import succeeds, DTYPE == np.float32
```

Happy to add a CI entry pinning the newest scikit-learn if that's useful.
