### PR TITLE
Add arm64 Linux wheel builds to CI/CD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           CIBW_SKIP: pp* *i686* *win32 *musllinux*
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9,<3.15'
           CIBW_BEFORE_BUILD: pip install --verbose --editable .
-          CIBW_ARCHS_LINUX: auto64
+          CIBW_ARCHS_LINUX: auto64 aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto64
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.0
         env:
@@ -28,6 +34,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto64 aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto64
+          CIBW_TEST_COMMAND: python -c "import quantile_forest; print(quantile_forest.__version__)"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Enable aarch64 architecture for Linux wheel builds in cibuildwheel to publish arm64 wheels to PyPI.

This change adds 'aarch64' to CIBW_ARCHS_LINUX, which will build arm64-compatible wheels on ubuntu-latest runners.